### PR TITLE
[FE] 게시글 삭제 기능 구현

### DIFF
--- a/app/_hooks/services/mutations/deletePost.tsx
+++ b/app/_hooks/services/mutations/deletePost.tsx
@@ -1,0 +1,22 @@
+'use client'
+import api from '@/app/_api/commonApi'
+import { useMutation } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+
+const deletePost = async (postId: number): Promise<{ message: string }> => {
+  const response = await api.delete(`/posts/${postId}`)
+  return response
+}
+export function useDeletePost() {
+  const router = useRouter()
+  return useMutation({
+    mutationFn: (postId: number) => deletePost(postId),
+    onSuccess: (response) => {
+      alert(response.message)
+      router.push('/')
+    },
+    onError: (response) => {
+      alert(response.message)
+    },
+  })
+}

--- a/app/_hooks/services/mutations/postWrite.tsx
+++ b/app/_hooks/services/mutations/postWrite.tsx
@@ -1,17 +1,22 @@
+'use client'
 import api from '@/app/_api/commonApi'
 import { IPost } from '@/app/_types/postTypes'
 import { useMutation } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
 
-const postWrite = async (writeData: IPost): Promise<any> => {
+const postWrite = async (
+  writeData: IPost,
+): Promise<{ data: { id: number }; message: string }> => {
   const response = await api.post('/posts', writeData)
   return response
 }
 export function usePostWrite() {
+  const router = useRouter()
   return useMutation({
     mutationFn: (writeData: IPost) => postWrite(writeData),
     onSuccess: (response) => {
-      console.log(response)
-      alert('게시글 첨부가 완료되었습니다.') // 임시, 게시글 디테일 페이지 작업 시 해당 게시물 디테일 페이지로 redirect구현 예정
+      alert(response.message)
+      router.push(`/detail/${response.data.id}`)
     },
   })
 }

--- a/app/_hooks/services/queries/userInfo.tsx
+++ b/app/_hooks/services/queries/userInfo.tsx
@@ -1,0 +1,14 @@
+import api from '@/app/_api/commonApi'
+import { useQuery } from '@tanstack/react-query'
+
+const getUserInfo = async () => {
+  const response = await api.get('/users')
+  return response.data
+}
+
+export default function useGetUserInfo() {
+  return useQuery({
+    queryKey: ['get-user-info'],
+    queryFn: () => getUserInfo(),
+  })
+}

--- a/app/detail/[id]/_components/Navigation.tsx
+++ b/app/detail/[id]/_components/Navigation.tsx
@@ -1,0 +1,46 @@
+'use client'
+import Header from '@/app/_components/common/header/page'
+import Back from '@/app/_components/common/header/_components/Back'
+import Heart from '@/app/_components/common/header/_components/Heart'
+import MoreMenu from '@/app/_components/common/header/_components/MoreMenu'
+import style from '../styles/navigation.module.scss'
+import { useState } from 'react'
+import { useDeletePost } from '@/app/_hooks/services/mutations/deletePost'
+import { useRouter } from 'next/navigation'
+import useGetUserInfo from '@/app/_hooks/services/queries/userInfo'
+
+interface NavigationProps {
+  postId: number
+  authorNickname: string
+}
+export default function Navigation({
+  postId,
+  authorNickname,
+}: NavigationProps) {
+  const [isToggle, setIsToggle] = useState(false)
+  const { mutate: postDelete } = useDeletePost()
+  const { data: userInfo, isLoading } = useGetUserInfo()
+  const router = useRouter()
+  return (
+    <div className={style.container}>
+      {!isLoading && (
+        <Header
+          leftSection={<Back />}
+          rightSection={[
+            <Heart />,
+            userInfo.credential.nickname === authorNickname && (
+              <MoreMenu clickEvent={() => setIsToggle(!isToggle)} />
+            ),
+          ]}
+        />
+      )}
+      {isToggle && (
+        <div className={style.dropdown}>
+          <div onClick={() => router.push('/write')}>게시글 수정</div>
+          <div className={style.line}></div>
+          <div onClick={() => postDelete(postId)}>게시글 삭제</div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -2,26 +2,26 @@ import styles from './styles/page.module.scss'
 import Content from './_components/Content'
 import Comment from './_components/Comment'
 import Sort from '/public/assets/sort.svg'
-import Header from '@/app/_components/common/header/page'
-import Back from '@/app/_components/common/header/_components/Back'
-import Heart from '@/app/_components/common/header/_components/Heart'
-import MoreMenu from '@/app/_components/common/header/_components/MoreMenu'
 import { PageProps } from '@/.next/types/app/layout'
 import api from '@/app/_api/commonApi'
 import formatDate from '@/app/_lib/formatDate'
+import Navigation from './_components/Navigation'
 
 export default async function Detail({ params }: PageProps) {
   const response = await api.get(`/posts/${params.id}`)
   const data = response.data
   return (
     <div className={styles.container}>
-      <Header leftSection={<Back />} rightSection={[<Heart />, <MoreMenu />]} />
+      <Navigation
+        postId={params.id}
+        authorNickname={data.author.credential.nickname}
+      />
       <Content
         title={data.title}
         nickName={
           data.isAnonymous
             ? `익명의 ${data.animalOfAuthor}`
-            : data.credential.nickname
+            : data.author.credential.nickname
         }
         content={data.content}
         tag={data.tag}

--- a/app/detail/[id]/styles/navigation.module.scss
+++ b/app/detail/[id]/styles/navigation.module.scss
@@ -1,0 +1,23 @@
+.container {
+  position: relative;
+}
+.dropdown {
+  width: 120px;
+  height: 80px;
+  position: absolute;
+  left: 70%;
+  background: #fff;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+.line {
+  width: 100%;
+  height: 0px;
+  border: 1px solid #ebebeb;
+  margin: 11px 0;
+}


### PR DESCRIPTION
이슈 번호: #58 
1. 게시글 삭제 기능을 구현했습니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/650bd3d4-b700-4d9d-bbca-8892e19dda11)
헤더의 메뉴버튼 클릭시 게시글 수정 / 삭제 드롭다운(임시 구현)이 나타납니다.
<img width="311" alt="image" src="https://github.com/waggle2/wagglewaggle/assets/87300419/a7a67348-b1db-41cb-9ac6-58362891778b">

삭제버튼 클릭 시 삭제가 완료되었다는 alert창이 뜨고 삭제가 완료됩니다.

2. 해당 게시물 작성자의 닉네임과 현재 로그인된 유저의 이메일이 다를 시 메뉴 버튼을 표시하지 않도록 구현했습니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/83c5cee6-4b36-48fa-bf86-e23c8f9fa61d)

3. 글쓰기 완료 시 해당 게시물 상세 페이지로 이동하는 기능을 추가하였습니다.
