### PR TITLE
[FE] 게시글 수정 기능 구현

### DIFF
--- a/app/_hooks/services/mutations/postWrite.tsx
+++ b/app/_hooks/services/mutations/postWrite.tsx
@@ -10,6 +10,14 @@ const postWrite = async (
   const response = await api.post('/posts', writeData)
   return response
 }
+
+const postModify = async (
+  writeData: IPost,
+  postId: number,
+): Promise<{ data: { id: number }; message: string }> => {
+  const response = await api.patch(`/posts/${postId}`, writeData)
+  return response
+}
 export function usePostWrite() {
   const router = useRouter()
   return useMutation({
@@ -17,6 +25,17 @@ export function usePostWrite() {
     onSuccess: (response) => {
       alert(response.message)
       router.push(`/detail/${response.data.id}`)
+    },
+  })
+}
+export function usePostModify(postId: number) {
+  const router = useRouter()
+  return useMutation({
+    mutationFn: (writeData: IPost) => postModify(writeData, postId),
+    onSuccess: (response) => {
+      alert(response.message)
+      router.push(`/detail/${response.data.id}`)
+      router.refresh()
     },
   })
 }

--- a/app/_hooks/services/queries/postLike.tsx
+++ b/app/_hooks/services/queries/postLike.tsx
@@ -1,0 +1,14 @@
+import api from '@/app/_api/commonApi'
+import { useQuery } from '@tanstack/react-query'
+
+const getPostLike = async (postId: number) => {
+  const response = await api.get(`/posts/${postId}`)
+  return response.data.likes
+}
+
+export default function useGetPostLike(postId: number) {
+  return useQuery({
+    queryKey: ['get-post-like'],
+    queryFn: () => getPostLike(postId),
+  })
+}

--- a/app/detail/[id]/_components/Navigation.tsx
+++ b/app/detail/[id]/_components/Navigation.tsx
@@ -36,7 +36,7 @@ export default function Navigation({
       )}
       {isToggle && (
         <div className={style.dropdown}>
-          <div onClick={() => router.push('/write')}>게시글 수정</div>
+          <div onClick={() => router.push(`/write/${postId}`)}>게시글 수정</div>
           <div className={style.line}></div>
           <div onClick={() => postDelete(postId)}>게시글 삭제</div>
         </div>

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -10,6 +10,7 @@ import Navigation from './_components/Navigation'
 export default async function Detail({ params }: PageProps) {
   const response = await api.get(`/posts/${params.id}`)
   const data = response.data
+  console.log(data)
   return (
     <div className={styles.container}>
       <Navigation

--- a/app/write/[id]/page.tsx
+++ b/app/write/[id]/page.tsx
@@ -1,0 +1,21 @@
+import api from '@/app/_api/commonApi'
+import Content from '../_components/Content'
+import styles from '../styles/page.module.scss'
+import { PageProps } from '@/.next/types/app/layout'
+
+export default async function Write({ params }: PageProps) {
+  const response = await api.get(`/posts/${params.id}`)
+  const data = response.data
+  return (
+    <div className={styles.container}>
+      <Content
+        postId={params.id}
+        editTitle={data.title}
+        editContent={data.content}
+        editCategory={data.category}
+        editTag={data.tag}
+        editIsAnonymous={data.isAnonymous}
+      />
+    </div>
+  )
+}

--- a/app/write/_components/ButtonSection.tsx
+++ b/app/write/_components/ButtonSection.tsx
@@ -9,6 +9,7 @@ interface ButtonSectionProps {
   setSelectedCategory: Dispatch<SetStateAction<number>>
   setSelectedTag: Dispatch<SetStateAction<number>>
   setIsAnonymous: Dispatch<SetStateAction<boolean>>
+  editIsAnonymous?: boolean
 }
 export default function ButtonSection({
   category,
@@ -18,6 +19,7 @@ export default function ButtonSection({
   setSelectedCategory,
   setSelectedTag,
   setIsAnonymous,
+  editIsAnonymous,
 }: ButtonSectionProps) {
   const isAnonymous = false
   return (
@@ -64,9 +66,18 @@ export default function ButtonSection({
         <span>익명</span>
         <label
           className={styles.toggle}
-          onClick={() => setIsAnonymous(!isAnonymous)}
+          onClick={() =>
+            setIsAnonymous(
+              editIsAnonymous !== null ? !editIsAnonymous : !isAnonymous,
+            )
+          }
         >
-          <input type="checkbox" />
+          <input
+            type="checkbox"
+            defaultChecked={
+              editIsAnonymous !== null ? editIsAnonymous : isAnonymous
+            }
+          />
           <span className={styles.slider}></span>
         </label>
       </div>

--- a/app/write/_components/Editor.tsx
+++ b/app/write/_components/Editor.tsx
@@ -15,12 +15,11 @@ const ReactQuill = dynamic(
 )
 interface EditorProps {
   setContent: Dispatch<SetStateAction<string>>
-  setImageUrls: Dispatch<SetStateAction<string[]>>
+  initialContent?: string
 }
-export default function Editor({ setContent, setImageUrls }: EditorProps) {
+export default function Editor({ setContent, initialContent }: EditorProps) {
   const { mutate: imageMutate } = usePostImage()
   const quillRef = useRef<any>()
-  const newImageUrls: string[] = []
   const imageHandler = () => {
     // file input 임의 생성
     const input = document.createElement('input')
@@ -43,8 +42,6 @@ export default function Editor({ setContent, setImageUrls }: EditorProps) {
                 const range = editor.getSelection()
                 editor.insertEmbed(range.index, 'image', response)
                 editor.setSelection(range.index + 1)
-                newImageUrls.push(response)
-                setImageUrls(newImageUrls)
               }
             },
           },
@@ -94,6 +91,7 @@ export default function Editor({ setContent, setImageUrls }: EditorProps) {
       theme="snow"
       modules={modules}
       formats={formats}
+      defaultValue={initialContent}
       onChange={setContent}
       placeholder="함께 나누고 싶은 이야기를 적어보세요"
       style={{ width: '100%' }}


### PR DESCRIPTION
이슈 번호:#61

1. 게시글 수정 기능을 구현했습니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/dc764dbc-05ca-409e-995f-2bd35cb0e559)
드롭다운 - 게시글 수정 클릭시 카테고리/태그/익명여부/제목/내용이 유지된 채로 글쓰기 페이지로 이동됩니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/a4bb6a01-45fb-4c19-b04a-6f43606b9400)
게시글 수정 완료시 alert로 수정 완료 메세지가 뜨며, detail 페이지로 리다이렉트 됩니다.
![스크린샷 2024-02-21 오후 9 12 43](https://github.com/waggle2/wagglewaggle/assets/87300419/9e4483bc-d718-4237-8571-5d9de57f41c3)
<img width="858" alt="image" src="https://github.com/waggle2/wagglewaggle/assets/87300419/20e23fb0-199a-4aa9-a56b-a43332722ee0">

2. 게시글 작성 시 등록 버튼을 눌렀을 때 첨부된 이미지 태그들이 imageUrls 배열에 들어갈 수 있도록 수정하였습니다. (기존: 이미지 첨부 할때마다, 수정: 등록 버튼 눌렀을 때)
