### PR TITLE
[FE] 게시글 좋아요 기능 구현

### DIFF
--- a/app/_components/common/header/_components/Heart.tsx
+++ b/app/_components/common/header/_components/Heart.tsx
@@ -2,11 +2,21 @@
 
 import { useRouter } from 'next/navigation'
 import HeartIcon from '@/public/assets/heart.svg'
+import FilledHeartIcon from '@/public/assets/heartFilled.svg'
 
-export default function Heart() {
+interface HeartProps {
+  isClicked: boolean
+  clickEvent: () => void
+}
+export default function Heart({ isClicked, clickEvent }: HeartProps) {
   const router = useRouter()
-  const clickEvent = () => {
-    //event
-  }
-  return <HeartIcon width="24" height="24" />
+  return (
+    <>
+      {isClicked ? (
+        <FilledHeartIcon onClick={clickEvent} />
+      ) : (
+        <HeartIcon width="24" height="24" onClick={clickEvent} />
+      )}
+    </>
+  )
 }

--- a/app/_components/reactQuery/QueryProvider.tsx
+++ b/app/_components/reactQuery/QueryProvider.tsx
@@ -6,7 +6,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experimental'
 
 export default function QueryProvider({ children }: React.PropsWithChildren) {
-  const [client] = useState(new QueryClient())
+  const [client] = useState(() => new QueryClient())
 
   return (
     <QueryClientProvider client={client}>

--- a/app/_hooks/services/mutations/postLike.tsx
+++ b/app/_hooks/services/mutations/postLike.tsx
@@ -1,0 +1,29 @@
+import api from '@/app/_api/commonApi'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const addPostLike = async (postId: number): Promise<{ message: string }> => {
+  const response = await api.post(`/likes/${postId}`, {})
+  return response
+}
+const deletePostLike = async (postId: number): Promise<{ message: string }> => {
+  const response = await api.delete(`/likes/${postId}`, {})
+  return response
+}
+export function useAddPostLike() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (postId: number) => addPostLike(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-post-like'] })
+    },
+  })
+}
+export function useDeletePostLike() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (postId: number) => deletePostLike(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-post-like'] })
+    },
+  })
+}

--- a/app/_hooks/services/queries/postLike.tsx
+++ b/app/_hooks/services/queries/postLike.tsx
@@ -3,12 +3,15 @@ import { useQuery } from '@tanstack/react-query'
 
 const getPostLike = async (postId: number) => {
   const response = await api.get(`/posts/${postId}`)
-  return response.data.likes
+  return {
+    likeCount: response.data.likes === null ? 0 : response.data.likes.length,
+    likes: response.data.likes === null ? [] : response.data.likes,
+  }
 }
 
 export default function useGetPostLike(postId: number) {
   return useQuery({
-    queryKey: ['get-post-like'],
-    queryFn: () => getPostLike(postId),
+    queryKey: ['get-post-like', postId],
+    queryFn: ({ queryKey }) => getPostLike(queryKey[1] as number),
   })
 }

--- a/app/detail/[id]/_components/Content.tsx
+++ b/app/detail/[id]/_components/Content.tsx
@@ -3,25 +3,27 @@ import HeartIcon from '/public/assets/heart.svg'
 import View from '/public/assets/view.svg'
 import styles from '../styles/content.module.scss'
 import DOMPurify from 'isomorphic-dompurify'
+import LikeSection from './LikeSection'
 
 interface ContentProps {
+  postId: number
   title: string
   nickName: string
   content: string
   tag: string
   category: string
   date: string
-  likes: number
   views: number
 }
 export default function Content({
+  postId,
   title,
   nickName,
   content,
   tag,
   category,
   date,
-  likes,
+
   views,
 }: ContentProps) {
   return (
@@ -48,10 +50,7 @@ export default function Content({
         <div />
       )}
       <div className={styles.buttonSection}>
-        <div>
-          <HeartIcon width="16" height="16" color="#8c8c8c" />
-          <span>{likes}</span>
-        </div>
+        <LikeSection postId={postId} />
         <div>
           <View width="16" height="16" color="#8c8c8c" />
           <span>{views}</span>

--- a/app/detail/[id]/_components/LikeSection.tsx
+++ b/app/detail/[id]/_components/LikeSection.tsx
@@ -1,0 +1,20 @@
+'use client'
+import useGetPostLike from '@/app/_hooks/services/queries/postLike'
+import HeartIcon from '/public/assets/heart.svg'
+
+interface LikeSectionProps {
+  postId: number
+}
+export default function LikeSection({ postId }: LikeSectionProps) {
+  const { data, isLoading } = useGetPostLike(postId)
+  return (
+    <>
+      {!isLoading && (
+        <div>
+          <HeartIcon width="16" height="16" color="#8c8c8c" />
+          <span>{data?.likeCount}</span>
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/detail/[id]/_components/Navigation.tsx
+++ b/app/detail/[id]/_components/Navigation.tsx
@@ -4,10 +4,15 @@ import Back from '@/app/_components/common/header/_components/Back'
 import Heart from '@/app/_components/common/header/_components/Heart'
 import MoreMenu from '@/app/_components/common/header/_components/MoreMenu'
 import style from '../styles/navigation.module.scss'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useDeletePost } from '@/app/_hooks/services/mutations/deletePost'
 import { useRouter } from 'next/navigation'
 import useGetUserInfo from '@/app/_hooks/services/queries/userInfo'
+import {
+  useAddPostLike,
+  useDeletePostLike,
+} from '@/app/_hooks/services/mutations/postLike'
+import useGetPostLike from '@/app/_hooks/services/queries/postLike'
 
 interface NavigationProps {
   postId: number
@@ -19,15 +24,27 @@ export default function Navigation({
 }: NavigationProps) {
   const [isToggle, setIsToggle] = useState(false)
   const { mutate: postDelete } = useDeletePost()
+  const { mutate: addPostLike } = useAddPostLike()
+  const { mutate: deletePostLike } = useDeletePostLike()
   const { data: userInfo, isLoading } = useGetUserInfo()
+  const { data: likeInfo, isLoading: isLikeLoading } = useGetPostLike(postId)
   const router = useRouter()
   return (
     <div className={style.container}>
-      {!isLoading && (
+      {!isLoading && !isLikeLoading && (
         <Header
           leftSection={<Back />}
           rightSection={[
-            <Heart />,
+            <Heart
+              isClicked={likeInfo?.likes.includes(userInfo.id)}
+              clickEvent={() => {
+                if (likeInfo?.likes.includes(userInfo.id)) {
+                  deletePostLike(postId)
+                } else {
+                  addPostLike(postId)
+                }
+              }}
+            />,
             userInfo.credential.nickname === authorNickname && (
               <MoreMenu clickEvent={() => setIsToggle(!isToggle)} />
             ),

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -18,6 +18,7 @@ export default async function Detail({ params }: PageProps) {
         authorNickname={data.author.credential.nickname}
       />
       <Content
+        postId={params.id}
         title={data.title}
         nickName={
           data.isAnonymous
@@ -28,7 +29,6 @@ export default async function Detail({ params }: PageProps) {
         tag={data.tag}
         category={data.category}
         date={formatDate(data.createdAt)}
-        likes={data.likes === null ? 0 : data.likes.length}
         views={data.views}
       />
       <div className={styles.boldLine}></div>

--- a/public/assets/heartFilled.svg
+++ b/public/assets/heartFilled.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" fill="white"/>
+<path d="M12 6.55707C9.77778 1.26305 2 1.82697 2 8.59392C2 15.3609 12 21 12 21C12 21 22 15.3609 22 8.59392C22 1.82697 14.2222 1.26305 12 6.55707Z" fill="#FF3A51" stroke="#FF3A52" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
1. 게시글 좋아요 기능을 구현했습니다.
좋아요 버튼 클릭시 헤더의 like 버튼이 빨간색으로 채워지고 게시글의 좋아요 숫자가 +1이 됩니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/7e618bdd-406b-4132-b317-5f8ae3790df6)

2. 게시글 좋아요 취소 기능을 구현했습니다.
이미 좋아요된 상태에서 좋아요 버튼 클릭 시 헤더의 like 버튼이 비워지고 게시글의 좋아요 숫자가 -1이 됩니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/213091ff-f679-4a9e-86e0-307787d66de8)
