### PR TITLE
[FE] 댓글 작성 기능 구현

### DIFF
--- a/app/_hooks/services/mutations/commentWrite.tsx
+++ b/app/_hooks/services/mutations/commentWrite.tsx
@@ -1,0 +1,19 @@
+import api from '@/app/_api/commonApi'
+import { IComment } from '@/app/_types/commentTypes'
+import { useMutation } from '@tanstack/react-query'
+
+const commentWrite = async (
+  commentData: IComment,
+  postId: number,
+): Promise<{ data: { id: number }; message: string }> => {
+  const response = await api.post(`/comments/${postId}`, commentData)
+  return response
+}
+export function useCommentWrite(postId: number) {
+  return useMutation({
+    mutationFn: (commentData: IComment) => commentWrite(commentData, postId),
+    onSuccess: (response) => {
+      alert(response.message)
+    },
+  })
+}

--- a/app/_hooks/services/mutations/commentWrite.tsx
+++ b/app/_hooks/services/mutations/commentWrite.tsx
@@ -1,6 +1,6 @@
 import api from '@/app/_api/commonApi'
 import { IComment } from '@/app/_types/commentTypes'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 const commentWrite = async (
   commentData: IComment,
@@ -10,10 +10,11 @@ const commentWrite = async (
   return response
 }
 export function useCommentWrite(postId: number) {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (commentData: IComment) => commentWrite(commentData, postId),
-    onSuccess: (response) => {
-      alert(response.message)
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-comments'] })
     },
   })
 }

--- a/app/_hooks/services/queries/comments.tsx
+++ b/app/_hooks/services/queries/comments.tsx
@@ -1,0 +1,14 @@
+import api from '@/app/_api/commonApi'
+import { useQuery } from '@tanstack/react-query'
+
+const getComments = async (postId: number) => {
+  const response = await api.get(`/comments?postId=${postId}`)
+  return response.data
+}
+
+export default function useGetComments(postId: number) {
+  return useQuery({
+    queryKey: ['get-comments', postId],
+    queryFn: ({ queryKey }) => getComments(queryKey[1] as number),
+  })
+}

--- a/app/_types/commentTypes.ts
+++ b/app/_types/commentTypes.ts
@@ -1,0 +1,4 @@
+export interface IComment {
+  content: string
+  isAnonymous: boolean
+}

--- a/app/detail/[id]/_components/Comment.tsx
+++ b/app/detail/[id]/_components/Comment.tsx
@@ -1,31 +1,48 @@
+'use client'
+import Sort from '/public/assets/sort.svg'
 import styles from '../styles/comment.module.scss'
-import Profile from '/public/assets/profile.svg'
-import EmpathyButton from './EmpathyButton'
-import MoreMenu from '@/app/_components/common/header/_components/MoreMenu'
-
+import CommentInfo from './CommentInfo'
+import CommentWrite from './CommentWrite'
+import useGetComments from '@/app/_hooks/services/queries/comments'
+import formatDate from '@/app/_lib/formatDate'
 interface CommentProps {
-  nickName: string
+  postId: number
 }
-export default function Comment({ nickName }: CommentProps) {
+export default function Comment({ postId }: CommentProps) {
+  const { data, isLoading } = useGetComments(postId)
   return (
-    <div className={styles.container}>
-      <div className={styles.profile}>
-        <div className={styles.profileCircle}>
-          <Profile width="26" height="23" />
-        </div>
-        <div className={styles.author}>
-          <div>
-            <h5>{nickName}</h5>
-            <span>2024-12-03 14:30</span>
+    <>
+      {!isLoading && (
+        <>
+          <div className={styles.commentInfo}>
+            <div>
+              <span>댓글</span>
+              <span>{data.length}</span>
+            </div>
+            <div>
+              <Sort width="14" height="14" />
+              <span>최신순</span>
+            </div>
           </div>
-          <MoreMenu />
-        </div>
-      </div>
-      <span>
-        미친거 아님? 너 그러다 잡혀가 정신차려 제발 이 각박한 세상에서
-        왜그러는거야
-      </span>
-      <EmpathyButton />
-    </div>
+          <CommentWrite postId={postId} />
+          {data.map((item: any) => {
+            return (
+              <>
+                <div className={styles.line} />
+                <CommentInfo
+                  nickName={
+                    item.isAnonymous
+                      ? `익명의 ${item.author.profileAnimal}`
+                      : item.author.credential.nickname
+                  }
+                  content={item.content}
+                  date={formatDate(item.updatedAt)}
+                />
+              </>
+            )
+          })}
+        </>
+      )}
+    </>
   )
 }

--- a/app/detail/[id]/_components/CommentInfo.tsx
+++ b/app/detail/[id]/_components/CommentInfo.tsx
@@ -1,0 +1,34 @@
+import styles from '../styles/commentInfo.module.scss'
+import Profile from '/public/assets/profile.svg'
+import EmpathyButton from './EmpathyButton'
+import MoreMenu from '@/app/_components/common/header/_components/MoreMenu'
+
+interface CommentInfoProps {
+  nickName: string
+  date: string
+  content: string
+}
+export default function CommentInfo({
+  nickName,
+  date,
+  content,
+}: CommentInfoProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.profile}>
+        <div className={styles.profileCircle}>
+          <Profile width="26" height="23" />
+        </div>
+        <div className={styles.author}>
+          <div>
+            <h5>{nickName}</h5>
+            <span>{date}</span>
+          </div>
+          <MoreMenu />
+        </div>
+      </div>
+      <span>{content}</span>
+      <EmpathyButton />
+    </div>
+  )
+}

--- a/app/detail/[id]/_components/CommentWrite.tsx
+++ b/app/detail/[id]/_components/CommentWrite.tsx
@@ -30,17 +30,19 @@ export default function CommentWrite({ postId }: CommentWriteProps) {
       </div>
       <div className={styles.commentWrapper}>
         <textarea
+          value={content}
           className={styles.comment}
           onChange={(e) => setContent(e.target.value)}
         />
         <div
           className={styles.commentSubmit}
-          onClick={() =>
+          onClick={() => {
             mutate({
               content: content,
               isAnonymous: isAnonymous,
             })
-          }
+            setContent('')
+          }}
         >
           확인
         </div>

--- a/app/detail/[id]/_components/CommentWrite.tsx
+++ b/app/detail/[id]/_components/CommentWrite.tsx
@@ -1,14 +1,49 @@
+'use client'
+import { useState } from 'react'
 import styles from '../styles/commentWrite.module.scss'
 import Profile from '/public/assets/profile.svg'
-export default function CommentWrite() {
+import { useCommentWrite } from '@/app/_hooks/services/mutations/commentWrite'
+
+interface CommentWriteProps {
+  postId: number
+}
+export default function CommentWrite({ postId }: CommentWriteProps) {
+  const [content, setContent] = useState('')
+  const [isAnonymous, setIsAnonymous] = useState(false)
+  const { mutate } = useCommentWrite(postId)
   return (
     <div className={styles.container}>
-      <div className={styles.profileCircle}>
-        <Profile width="26" height="23" />
+      <div className={styles.profileSection}>
+        <div className={styles.profileCircle}>
+          <Profile width="26" height="23" />
+        </div>
+        <div className={styles.toggleBox}>
+          <span>익명</span>
+          <label className={styles.toggle}>
+            <input
+              type="checkbox"
+              onClick={() => setIsAnonymous(!isAnonymous)}
+            />
+            <span className={styles.slider}></span>
+          </label>
+        </div>
       </div>
       <div className={styles.commentWrapper}>
-        <textarea className={styles.comment} />
-        <div className={styles.commentSubmit}>확인</div>
+        <textarea
+          className={styles.comment}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <div
+          className={styles.commentSubmit}
+          onClick={() =>
+            mutate({
+              content: content,
+              isAnonymous: isAnonymous,
+            })
+          }
+        >
+          확인
+        </div>
       </div>
     </div>
   )

--- a/app/detail/[id]/_components/CommentWrite.tsx
+++ b/app/detail/[id]/_components/CommentWrite.tsx
@@ -1,0 +1,15 @@
+import styles from '../styles/commentWrite.module.scss'
+import Profile from '/public/assets/profile.svg'
+export default function CommentWrite() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.profileCircle}>
+        <Profile width="26" height="23" />
+      </div>
+      <div className={styles.commentWrapper}>
+        <textarea className={styles.comment} />
+        <div className={styles.commentSubmit}>확인</div>
+      </div>
+    </div>
+  )
+}

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -6,6 +6,7 @@ import { PageProps } from '@/.next/types/app/layout'
 import api from '@/app/_api/commonApi'
 import formatDate from '@/app/_lib/formatDate'
 import Navigation from './_components/Navigation'
+import CommentWrite from './_components/CommentWrite'
 
 export default async function Detail({ params }: PageProps) {
   const response = await api.get(`/posts/${params.id}`)
@@ -32,6 +33,7 @@ export default async function Detail({ params }: PageProps) {
         views={data.views}
       />
       <div className={styles.boldLine}></div>
+      <CommentWrite />
       <div className={styles.commentInfo}>
         <div>
           <span>댓글</span>

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -33,7 +33,6 @@ export default async function Detail({ params }: PageProps) {
         views={data.views}
       />
       <div className={styles.boldLine}></div>
-      <CommentWrite />
       <div className={styles.commentInfo}>
         <div>
           <span>댓글</span>
@@ -44,6 +43,8 @@ export default async function Detail({ params }: PageProps) {
           <span>최신순</span>
         </div>
       </div>
+      <CommentWrite postId={params.id} />
+      <div className={styles.line} />
       <Comment nickName="익명의 냥이" />
       <div className={styles.line} />
       <Comment nickName="익명의 냥이" />

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -1,12 +1,10 @@
 import styles from './styles/page.module.scss'
 import Content from './_components/Content'
 import Comment from './_components/Comment'
-import Sort from '/public/assets/sort.svg'
 import { PageProps } from '@/.next/types/app/layout'
 import api from '@/app/_api/commonApi'
 import formatDate from '@/app/_lib/formatDate'
 import Navigation from './_components/Navigation'
-import CommentWrite from './_components/CommentWrite'
 
 export default async function Detail({ params }: PageProps) {
   const response = await api.get(`/posts/${params.id}`)
@@ -33,23 +31,7 @@ export default async function Detail({ params }: PageProps) {
         views={data.views}
       />
       <div className={styles.boldLine}></div>
-      <div className={styles.commentInfo}>
-        <div>
-          <span>댓글</span>
-          <span>2</span>
-        </div>
-        <div>
-          <Sort width="14" height="14" />
-          <span>최신순</span>
-        </div>
-      </div>
-      <CommentWrite postId={params.id} />
-      <div className={styles.line} />
-      <Comment nickName="익명의 냥이" />
-      <div className={styles.line} />
-      <Comment nickName="익명의 냥이" />
-      <div className={styles.line} />
-      <Comment nickName="익명의 냥이" />
+      <Comment postId={params.id} />
     </div>
   )
 }

--- a/app/detail/[id]/styles/comment.module.scss
+++ b/app/detail/[id]/styles/comment.module.scss
@@ -1,31 +1,17 @@
-.container {
-  padding: 16px;
-  position: relative;
+.line {
+  width: 92%;
+  height: 0px;
+  border: 1px solid #f6f6f6;
+  margin: 0 auto;
 }
-.profile {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  h5 {
-    margin: 0;
-  }
-  span {
-    color: #8c8c8c;
-  }
-  margin-bottom: 12px;
-}
-.author {
-  width: 90%;
+.commentInfo {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-}
-.profileCircle {
-  width: 40px;
-  height: 40px;
-  background-color: #ffe138;
-  border-radius: 50px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  font-size: 13px;
+  div {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  padding: 16px 16px 0 16px;
 }

--- a/app/detail/[id]/styles/commentInfo.module.scss
+++ b/app/detail/[id]/styles/commentInfo.module.scss
@@ -1,0 +1,31 @@
+.container {
+  padding: 16px;
+  position: relative;
+}
+.profile {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  h5 {
+    margin: 0;
+  }
+  span {
+    color: #8c8c8c;
+  }
+  margin-bottom: 12px;
+}
+.author {
+  width: 90%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.profileCircle {
+  width: 40px;
+  height: 40px;
+  background-color: #ffe138;
+  border-radius: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/detail/[id]/styles/commentWrite.module.scss
+++ b/app/detail/[id]/styles/commentWrite.module.scss
@@ -1,0 +1,44 @@
+.container {
+  text-align: center;
+  padding: 16px;
+  display: flex;
+  gap: 8px;
+}
+.profileCircle {
+  width: 40px;
+  height: 40px;
+  background-color: #ffe138;
+  border-radius: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.commentWrapper {
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+}
+.comment {
+  width: 100%;
+  height: 60px;
+  border: 2px solid #ebebeb;
+  border-radius: 8px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+  resize: none;
+  padding: 8px;
+  &:focus {
+    outline: none;
+  }
+}
+.commentSubmit {
+  width: 100%;
+  padding: 8px;
+  background: #2fd714;
+  color: #fff;
+  border-radius: 8px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  cursor: pointer;
+}

--- a/app/detail/[id]/styles/commentWrite.module.scss
+++ b/app/detail/[id]/styles/commentWrite.module.scss
@@ -4,6 +4,13 @@
   display: flex;
   gap: 8px;
 }
+.profileSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  justify-content: center;
+}
 .profileCircle {
   width: 40px;
   height: 40px;
@@ -21,7 +28,7 @@
 .comment {
   width: 100%;
   height: 60px;
-  border: 2px solid #ebebeb;
+  border: 1px solid #ebebeb;
   border-radius: 8px;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
@@ -41,4 +48,56 @@
   border-top-right-radius: 0;
   border-top-left-radius: 0;
   cursor: pointer;
+}
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 18px;
+  margin-top: 2px;
+}
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 14px;
+}
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 12px;
+  width: 12px;
+  left: 2.5px;
+  bottom: 3px;
+  background-color: white;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+input:checked + .slider {
+  background-color: #2fd714;
+}
+input:focus + .slider {
+  box-shadow: 0 0 1px #2fd714;
+}
+input:checked + .slider:before {
+  -webkit-transform: translateX(12px);
+  -ms-transform: translateX(12px);
+  transform: translateX(12px);
+}
+.toggleBox {
+  font-weight: normal;
+  font-size: 11px;
+  color: #6b6b6b;
 }

--- a/app/detail/[id]/styles/page.module.scss
+++ b/app/detail/[id]/styles/page.module.scss
@@ -2,23 +2,6 @@
   font-size: 14px;
   background-color: #fff;
 }
-.line {
-  width: 92%;
-  height: 0px;
-  border: 1px solid #f6f6f6;
-  margin: 0 auto;
-}
-.commentInfo {
-  display: flex;
-  justify-content: space-between;
-  font-size: 13px;
-  div {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-  }
-  padding: 16px 16px 0 16px;
-}
 .boldLine {
   width: 100%;
   height: 0px;


### PR DESCRIPTION
1. 댓글 작성 폼 UI(임시) 구현, 특정 게시글의 전체 댓글을 가져오는 기능을 구현했습니다.

![image](https://github.com/waggle2/wagglewaggle/assets/87300419/0f6d0abe-fe9a-4210-8251-64429a68323d)

2. 댓글 작성 기능을 구현하였습니다. 확인버튼 클릭 시 댓글 작성 api가 호출되고 화면에 새 댓글이 나타납니다.
<img width="726" alt="image" src="https://github.com/waggle2/wagglewaggle/assets/87300419/ecca39e9-f619-4f19-b80b-ce1d45045083">

![스크린샷 2024-02-23 오전 2 55 53](https://github.com/waggle2/wagglewaggle/assets/87300419/b5d3c1e7-fbab-4763-ac86-b433832341a2)
