### PR TITLE
[FE] 댓글 수정, 삭제 기능 구현

### DIFF
--- a/app/_hooks/services/mutations/commentDelete.tsx
+++ b/app/_hooks/services/mutations/commentDelete.tsx
@@ -1,0 +1,22 @@
+import api from '@/app/_api/commonApi'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const commentDelete = async (
+  commentId: number,
+): Promise<{ message: string }> => {
+  const response = await api.delete(`/comments/${commentId}`, {})
+  return response.message
+}
+export function useCommentDelete(commentId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => commentDelete(commentId),
+    onSuccess: (response) => {
+      alert(response)
+      queryClient.invalidateQueries({ queryKey: ['get-comments'] })
+    },
+    onError: (response) => {
+      alert(response)
+    },
+  })
+}

--- a/app/_hooks/services/mutations/commentWrite.tsx
+++ b/app/_hooks/services/mutations/commentWrite.tsx
@@ -9,12 +9,35 @@ const commentWrite = async (
   const response = await api.post(`/comments/${postId}`, commentData)
   return response
 }
+const commentModify = async (
+  commentData: IComment,
+  commentId: number,
+): Promise<{ data: { id: number }; message: string }> => {
+  const response = await api.patch(`/comments/${commentId}`, commentData)
+  return response
+}
 export function useCommentWrite(postId: number) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (commentData: IComment) => commentWrite(commentData, postId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['get-comments'] })
+    },
+    onError: (response) => {
+      alert(response)
+    },
+  })
+}
+export function useCommentModify(commentId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (commentData: IComment) =>
+      commentModify(commentData, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['get-comments'] })
+    },
+    onError: (response) => {
+      alert(response)
     },
   })
 }

--- a/app/detail/[id]/_components/Comment.tsx
+++ b/app/detail/[id]/_components/Comment.tsx
@@ -5,14 +5,18 @@ import CommentInfo from './CommentInfo'
 import CommentWrite from './CommentWrite'
 import useGetComments from '@/app/_hooks/services/queries/comments'
 import formatDate from '@/app/_lib/formatDate'
+import useGetUserInfo from '@/app/_hooks/services/queries/userInfo'
+import { useState } from 'react'
 interface CommentProps {
   postId: number
 }
 export default function Comment({ postId }: CommentProps) {
   const { data, isLoading } = useGetComments(postId)
+  const { data: userInfo, isLoading: isUserLoading } = useGetUserInfo()
+  const [editIdx, setEditIdx] = useState<number | null>(null)
   return (
     <>
-      {!isLoading && (
+      {!isLoading && !isUserLoading && (
         <>
           <div className={styles.commentInfo}>
             <div>
@@ -24,20 +28,38 @@ export default function Comment({ postId }: CommentProps) {
               <span>최신순</span>
             </div>
           </div>
-          <CommentWrite postId={postId} />
-          {data.map((item: any) => {
+          <CommentWrite postId={postId} isEdit={false} />
+          {data.map((item: any, idx: number) => {
             return (
               <>
                 <div className={styles.line} />
-                <CommentInfo
-                  nickName={
-                    item.isAnonymous
-                      ? `익명의 ${item.author.profileAnimal}`
-                      : item.author.credential.nickname
-                  }
-                  content={item.content}
-                  date={formatDate(item.updatedAt)}
-                />
+                {idx === editIdx ? (
+                  <CommentWrite
+                    commentId={item.id}
+                    postId={postId}
+                    isEdit={idx === editIdx}
+                    setEditIdx={setEditIdx}
+                    initialContent={item.content}
+                    initialAnonymous={item.isAnonymous}
+                  />
+                ) : (
+                  <CommentInfo
+                    commentId={item.id}
+                    nickName={
+                      item.isAnonymous
+                        ? `익명의 ${item.author.profileAnimal}`
+                        : item.author.credential.nickname
+                    }
+                    content={item.content}
+                    date={formatDate(item.updatedAt)}
+                    isEditable={
+                      userInfo.credential.nickname ===
+                      item.author.credential.nickname
+                    }
+                    idx={idx}
+                    setEditIdx={setEditIdx}
+                  />
+                )}
               </>
             )
           })}

--- a/app/detail/[id]/_components/CommentInfo.tsx
+++ b/app/detail/[id]/_components/CommentInfo.tsx
@@ -2,17 +2,29 @@ import styles from '../styles/commentInfo.module.scss'
 import Profile from '/public/assets/profile.svg'
 import EmpathyButton from './EmpathyButton'
 import MoreMenu from '@/app/_components/common/header/_components/MoreMenu'
+import { Dispatch, SetStateAction, useState } from 'react'
+import { useCommentDelete } from '@/app/_hooks/services/mutations/commentDelete'
 
 interface CommentInfoProps {
+  commentId: number
   nickName: string
   date: string
   content: string
+  isEditable: boolean
+  idx: number
+  setEditIdx: Dispatch<SetStateAction<number | null>>
 }
 export default function CommentInfo({
+  commentId,
   nickName,
   date,
   content,
+  isEditable,
+  idx,
+  setEditIdx,
 }: CommentInfoProps) {
+  const [isToggle, setIsToggle] = useState(false)
+  const { mutate } = useCommentDelete(commentId)
   return (
     <div className={styles.container}>
       <div className={styles.profile}>
@@ -24,8 +36,22 @@ export default function CommentInfo({
             <h5>{nickName}</h5>
             <span>{date}</span>
           </div>
-          <MoreMenu />
+          {isEditable && <MoreMenu clickEvent={() => setIsToggle(!isToggle)} />}
         </div>
+        {isToggle && (
+          <div className={styles.dropdown}>
+            <div onClick={() => setEditIdx(idx)}>댓글 수정</div>
+            <div className={styles.line}></div>
+            <div
+              onClick={() => {
+                mutate()
+                setIsToggle(!isToggle)
+              }}
+            >
+              댓글 삭제
+            </div>
+          </div>
+        )}
       </div>
       <span>{content}</span>
       <EmpathyButton />

--- a/app/detail/[id]/_components/CommentWrite.tsx
+++ b/app/detail/[id]/_components/CommentWrite.tsx
@@ -1,16 +1,35 @@
 'use client'
-import { useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import styles from '../styles/commentWrite.module.scss'
 import Profile from '/public/assets/profile.svg'
-import { useCommentWrite } from '@/app/_hooks/services/mutations/commentWrite'
+import {
+  useCommentModify,
+  useCommentWrite,
+} from '@/app/_hooks/services/mutations/commentWrite'
+import XmarkIcon from '@/public/assets/xmark.svg'
 
 interface CommentWriteProps {
+  commentId?: number
   postId: number
+  isEdit: boolean
+  setEditIdx?: Dispatch<SetStateAction<number | null>>
+  initialContent?: string
+  initialAnonymous?: boolean
 }
-export default function CommentWrite({ postId }: CommentWriteProps) {
-  const [content, setContent] = useState('')
-  const [isAnonymous, setIsAnonymous] = useState(false)
+export default function CommentWrite({
+  commentId,
+  postId,
+  isEdit,
+  setEditIdx,
+  initialContent,
+  initialAnonymous,
+}: CommentWriteProps) {
+  const [content, setContent] = useState(initialContent ? initialContent : '')
+  const [isAnonymous, setIsAnonymous] = useState(
+    initialAnonymous ? initialAnonymous : false,
+  )
   const { mutate } = useCommentWrite(postId)
+  const { mutate: commentModify } = useCommentModify(commentId as number)
   return (
     <div className={styles.container}>
       <div className={styles.profileSection}>
@@ -22,6 +41,7 @@ export default function CommentWrite({ postId }: CommentWriteProps) {
           <label className={styles.toggle}>
             <input
               type="checkbox"
+              defaultChecked={initialAnonymous ? initialAnonymous : false}
               onClick={() => setIsAnonymous(!isAnonymous)}
             />
             <span className={styles.slider}></span>
@@ -29,6 +49,12 @@ export default function CommentWrite({ postId }: CommentWriteProps) {
         </div>
       </div>
       <div className={styles.commentWrapper}>
+        {isEdit && setEditIdx && (
+          <div className={styles.cancleButton}>
+            <XmarkIcon onClick={() => setEditIdx(null)} />
+          </div>
+        )}
+
         <textarea
           value={content}
           className={styles.comment}
@@ -37,10 +63,22 @@ export default function CommentWrite({ postId }: CommentWriteProps) {
         <div
           className={styles.commentSubmit}
           onClick={() => {
-            mutate({
-              content: content,
-              isAnonymous: isAnonymous,
-            })
+            if (content === '') {
+              alert('댓글을 입력해주세요.')
+              return
+            }
+            if (isEdit && setEditIdx) {
+              commentModify({
+                content: content,
+                isAnonymous: isAnonymous as boolean,
+              })
+              setEditIdx(null)
+            } else {
+              mutate({
+                content: content,
+                isAnonymous: isAnonymous as boolean,
+              })
+            }
             setContent('')
           }}
         >

--- a/app/detail/[id]/styles/commentInfo.module.scss
+++ b/app/detail/[id]/styles/commentInfo.module.scss
@@ -29,3 +29,24 @@
   justify-content: center;
   align-items: center;
 }
+.dropdown {
+  width: 100px;
+  height: 80px;
+  position: absolute;
+  left: 75%;
+  top: 50px;
+  background: #fff;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+.line {
+  width: 100%;
+  height: 0px;
+  border: 1px solid #ebebeb;
+  margin: 11px 0;
+}

--- a/app/detail/[id]/styles/commentWrite.module.scss
+++ b/app/detail/[id]/styles/commentWrite.module.scss
@@ -24,6 +24,7 @@
   width: 90%;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 .comment {
   width: 100%;
@@ -100,4 +101,11 @@ input:checked + .slider:before {
   font-weight: normal;
   font-size: 11px;
   color: #6b6b6b;
+}
+.cancleButton {
+  position: absolute;
+  width: 20px;
+  left: 93%;
+  top: 4px;
+  opacity: 50%;
 }


### PR DESCRIPTION
이슈 번호:#69

- 댓글의 글쓴이와 현재 로그인된 사람의 닉네임이 다를 시 메뉴버튼이 나타나지 않습니다.
![스크린샷 2024-02-25 오후 10 18 23](https://github.com/waggle2/wagglewaggle/assets/87300419/851b0bfd-337c-4ec7-b110-065de63251a0)

- 댓글의 글쓴이와 현재 로그인된 사람의 닉네임이 같을 경우 수정 / 삭제 드롭다운이 나타납니다.(임시)
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/02b89148-1c5a-441e-8d31-8e41d3189cb3)

- 수정 버튼 클릭 시 댓글 작성 UI가 나타나고 익명 상태, 수정 전 댓글 내용들이 반영된 상태로 나타납니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/5b56a3a1-b250-4aaa-bf89-c696b7a95517)

- 댓글을 수정하고 확인 버튼을 누르면 실시간으로 수정상태가 반영되고, X버튼을 누르면 수정이 취소됩니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/2cf3a347-c625-44ba-8169-65b9cbe75275)

- 드롭다운에서 삭제를 클릭하면 댓글이 삭제되었다는 메세지가 alert 되고 댓글이 삭제됩니다.