### PR TITLE
[FE] 댓글 공감하기 기능 구현

### DIFF
--- a/app/_hooks/services/mutations/stickers.tsx
+++ b/app/_hooks/services/mutations/stickers.tsx
@@ -1,0 +1,63 @@
+import api from '@/app/_api/commonApi'
+import { ISticker } from '@/app/_types/stickerTypes'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const addStikers = async (
+  commentId: number,
+  animal: string,
+): Promise<{
+  data: { id: number }
+  message: string
+}> => {
+  const response = await api.post(`/stickers/${commentId}`, { animal: animal })
+  return response
+}
+const modifyStikers = async (
+  id: number,
+  animal: string,
+): Promise<{
+  data: { id: number }
+  message: string
+}> => {
+  const response = await api.patch(`/stickers/${id}`, { animal: animal })
+  return response
+}
+const deleteStikers = async (
+  id: number,
+): Promise<{
+  message: string
+}> => {
+  const response = await api.delete(`/stickers/${id}`)
+  return response
+}
+export function useAddStikers(commentId: number) {
+  return useMutation({
+    mutationFn: (animal: string) => addStikers(commentId, animal),
+  })
+}
+export function useModifyStikers() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, animal }: ISticker) => modifyStikers(id, animal),
+    onSuccess: (response) => {
+      alert(response.message)
+      queryClient.invalidateQueries({ queryKey: ['get-comments'] })
+    },
+    onError: (response) => {
+      alert(response.message)
+    },
+  })
+}
+export function useDeleteStikers() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => deleteStikers(id),
+    onSuccess: (response) => {
+      alert(response.message)
+      queryClient.invalidateQueries({ queryKey: ['get-comments'] })
+    },
+    onError: (response) => {
+      alert(response.message)
+    },
+  })
+}

--- a/app/_types/stickerTypes.ts
+++ b/app/_types/stickerTypes.ts
@@ -1,0 +1,4 @@
+export interface ISticker {
+  id: number
+  animal: string
+}

--- a/app/detail/[id]/_components/AnimalEmpathy.tsx
+++ b/app/detail/[id]/_components/AnimalEmpathy.tsx
@@ -3,25 +3,55 @@ import Bear from '/public/assets/bearEmoji.svg'
 import Dog from '/public/assets/dogEmoji.svg'
 import Fox from '/public/assets/foxEmoji.svg'
 import styles from '../styles/animalEmpathy.module.scss'
+import { useEffect, useState } from 'react'
 
-export default function AnimalEmpathy() {
+interface AnimalEmpathyProps {
+  stickers: {
+    userId: string
+    id: number
+    animal: string
+  }[]
+}
+export default function AnimalEmpathy({ stickers }: AnimalEmpathyProps) {
+  const [count, setCount] = useState<{
+    [key: string]: number
+  }>({
+    고냥이: 0,
+    곰돌이: 0,
+    댕댕이: 0,
+    폭스: 0,
+  })
+  useEffect(() => {
+    const newCount: {
+      [key: string]: number
+    } = {
+      고냥이: 0,
+      곰돌이: 0,
+      댕댕이: 0,
+      폭스: 0,
+    }
+    stickers.forEach((item) => {
+      newCount[item.animal]++
+    })
+    setCount(newCount)
+  }, [stickers])
   return (
     <div className={styles.container}>
       <div>
         <Cat width="20" height="20" />
-        <span>123</span>
+        <span>{count['고냥이']}</span>
       </div>
       <div>
         <Bear width="20" height="20" />
-        <span>14</span>
+        <span>{count['곰돌이']}</span>
       </div>
       <div>
         <Dog width="20" height="20" />
-        <span>2</span>
+        <span>{count['댕댕이']}</span>
       </div>
       <div>
         <Fox width="20" height="20" />
-        <span>1</span>
+        <span>{count['폭스']}</span>
       </div>
     </div>
   )

--- a/app/detail/[id]/_components/Comment.tsx
+++ b/app/detail/[id]/_components/Comment.tsx
@@ -58,6 +58,8 @@ export default function Comment({ postId }: CommentProps) {
                     }
                     idx={idx}
                     setEditIdx={setEditIdx}
+                    stickers={item.stickers}
+                    userId={userInfo.id}
                   />
                 )}
               </>

--- a/app/detail/[id]/_components/CommentInfo.tsx
+++ b/app/detail/[id]/_components/CommentInfo.tsx
@@ -13,6 +13,12 @@ interface CommentInfoProps {
   isEditable: boolean
   idx: number
   setEditIdx: Dispatch<SetStateAction<number | null>>
+  stickers: {
+    id: number
+    animal: string
+    userId: string
+  }[]
+  userId: string
 }
 export default function CommentInfo({
   commentId,
@@ -22,6 +28,8 @@ export default function CommentInfo({
   isEditable,
   idx,
   setEditIdx,
+  stickers,
+  userId,
 }: CommentInfoProps) {
   const [isToggle, setIsToggle] = useState(false)
   const { mutate } = useCommentDelete(commentId)
@@ -54,7 +62,11 @@ export default function CommentInfo({
         )}
       </div>
       <span>{content}</span>
-      <EmpathyButton />
+      <EmpathyButton
+        commentId={commentId}
+        stickers={stickers}
+        userId={userId}
+      />
     </div>
   )
 }

--- a/app/detail/[id]/_components/EmpathyButton.tsx
+++ b/app/detail/[id]/_components/EmpathyButton.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import styles from '../styles/empathyButton.module.scss'
 import AnimalEmpathy from './AnimalEmpathy'
 import Empathy from '/public/assets/empathy.svg'
@@ -7,18 +7,93 @@ import CatEmoji from '/public/assets/catEmoji.svg'
 import BearEmoji from '/public/assets/bearEmoji.svg'
 import DogEmoji from '/public/assets/dogEmoji.svg'
 import FoxEmoji from '/public/assets/foxEmoji.svg'
+import {
+  useAddStikers,
+  useDeleteStikers,
+  useModifyStikers,
+} from '@/app/_hooks/services/mutations/stickers'
+import { useQueryClient } from '@tanstack/react-query'
 
-export default function EmpathyButton() {
+interface EmpathyButtonProps {
+  commentId: number
+  stickers: {
+    userId: string
+    id: number
+    animal: string
+  }[]
+  userId: string
+}
+export default function EmpathyButton({
+  commentId,
+  stickers,
+  userId,
+}: EmpathyButtonProps) {
   const [isClick, setIsClick] = useState(false)
-
+  const [animal, setAnimal] = useState('')
+  const [stickerId, setStickerId] = useState(0)
+  const [isEmpathy, setIsEmpathy] = useState(false)
+  const { mutate: addStikers } = useAddStikers(commentId)
+  const { mutate: modifyStickers } = useModifyStikers()
+  const { mutate: deleteStickers } = useDeleteStikers()
+  const queryClient = useQueryClient()
+  const handleEmpathy = (type: string) => {
+    if (type === animal) {
+      deleteStickers(stickerId)
+      setAnimal('')
+      setIsEmpathy(false)
+    } else {
+      setAnimal(type)
+      if (isEmpathy) {
+        modifyStickers({ id: stickerId, animal: type })
+      } else {
+        addStikers(type, {
+          onSuccess: (response) => {
+            setStickerId(response.data.id)
+            setIsEmpathy(true)
+            queryClient.invalidateQueries({ queryKey: ['get-comments'] })
+            alert(response.message)
+          },
+          onError: (response) => {
+            alert(response.message)
+          },
+        })
+      }
+    }
+    setIsClick(false)
+  }
+  useEffect(() => {
+    stickers.forEach((item) => {
+      if (item.userId.includes(userId)) {
+        setIsEmpathy(true)
+        setStickerId(item.id)
+        setAnimal(item.animal)
+      }
+    })
+  }, [])
   return (
     <>
       {isClick && (
         <div className={styles.selectAnimal}>
-          <CatEmoji width="32" height="32" />
-          <BearEmoji width="32" height="32" />
-          <DogEmoji width="32" height="32" />
-          <FoxEmoji width="32" height="32" />
+          <CatEmoji
+            width="32"
+            height="32"
+            onClick={() => handleEmpathy('고냥이')}
+          />
+          <BearEmoji
+            width="32"
+            height="32"
+            onClick={() => handleEmpathy('곰돌이')}
+          />
+          <DogEmoji
+            width="32"
+            height="32"
+            onClick={() => handleEmpathy('댕댕이')}
+          />
+          <FoxEmoji
+            width="32"
+            height="32"
+            onClick={() => handleEmpathy('폭스')}
+          />
         </div>
       )}
 
@@ -30,7 +105,7 @@ export default function EmpathyButton() {
           <Empathy />
           <span>공감하기</span>
         </div>
-        <AnimalEmpathy />
+        <AnimalEmpathy stickers={stickers} />
       </div>
     </>
   )

--- a/app/detail/[id]/styles/empathyButton.module.scss
+++ b/app/detail/[id]/styles/empathyButton.module.scss
@@ -29,4 +29,5 @@
   padding: 6px 8px;
   top: 86%;
   box-shadow: 0 0 16px #ccc;
+  cursor: pointer;
 }


### PR DESCRIPTION
이슈 번호:#72

1. 공감하기 스티커 추가 기능을 구현했습니다.

![image](https://github.com/waggle2/wagglewaggle/assets/87300419/7b385ba6-360c-4a00-a80c-236d05639bb1)\
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/6e9b80e5-167a-4e24-a157-1443be211a8c)

원하는 동물스티커를 클릭하면 해당 동물의 공감스티커 카운트가 +1됩니다.

2. 공감하기 스티커 수정 기능을 구현했습니다.

![image](https://github.com/waggle2/wagglewaggle/assets/87300419/1dbeae83-50c8-416f-8848-04a1273978b8)
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/886215d1-13d9-4865-bb53-e591d41646a4)

이전에 공감한 댓글에서 다른 동물을 선택할 시 이전 선택한 동물의 카운트가 -1, 새로 선택한 동물의 카운트가 +1됩니다.

3. 공감하기 스티커 삭제 기능을 구현했습니다.

![image](https://github.com/waggle2/wagglewaggle/assets/87300419/3675c1f6-4376-4489-84c7-ead4ca0bdbfc)
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/5d8bf76c-5a3f-4aed-88c6-025652d4fc92)

이전에 공감한 댓글에서 같은 동물을 선택할 시 선택한 동물의 카운트가 -1됩니다.
