### PR TITLE
[FE] 본인인증 기능 구현

### DIFF
--- a/app/_components/postPreview/_components/Post.tsx
+++ b/app/_components/postPreview/_components/Post.tsx
@@ -1,14 +1,8 @@
-import DOMPurify from 'isomorphic-dompurify'
-
 import style from './post.module.scss'
-
-import Like from '@/public/assets/like.svg'
-import Comment from '@/public/assets/comment.svg'
-import View from '@/public/assets/view.svg'
-
 import Link from '@/node_modules/next/link'
 import { formatDate } from '@/app/_lib/formatDate'
 import Profile from './Profile'
+import PostDetail from './PostDetail'
 
 type Props = {
   profile: {
@@ -52,37 +46,7 @@ export default function Post({ profile, post }: Props) {
         </Link>
         <div className={style.time}>{formatDate(post.time)}</div>
       </div>
-      <Link href={`/detail/${post.id}`}>
-        <div className={style.contentContainer}>
-          <div className={style.title}>{post.title}</div>
-          {typeof window ? (
-            <div
-              className={style.content}
-              dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(post.content),
-              }}
-            /> //js코드 실행 방지용 라이브러리 사용(해킹 방지)
-          ) : (
-            <div />
-          )}
-        </div>
-        <div className={style.postInfoContainer}>
-          <div className={style.postInfoWrapper}>
-            <Like />
-            <span className={style.likes}>
-              {post.likes ? post.likes.length : 0}
-            </span>
-          </div>
-          <div className={style.postInfoWrapper}>
-            <Comment />
-            <span className={style.likes}>{post.comments}</span>
-          </div>
-          <div className={style.postInfoWrapper}>
-            <View width="15" height="14" />
-            <span className={style.likes}>{post.views}</span>
-          </div>
-        </div>
-      </Link>
+      <PostDetail post={post} />
     </div>
   )
 }

--- a/app/_components/postPreview/_components/PostDetail.tsx
+++ b/app/_components/postPreview/_components/PostDetail.tsx
@@ -1,0 +1,75 @@
+'use client'
+import DOMPurify from 'isomorphic-dompurify'
+import style from './post.module.scss'
+import Like from '@/public/assets/like.svg'
+import Comment from '@/public/assets/comment.svg'
+import View from '@/public/assets/view.svg'
+import { useRouter } from 'next/navigation'
+import userVerify from '@/app/_lib/userVerify'
+import api from '@/app/_api/commonApi'
+
+type Props = {
+  post: {
+    id: number
+    tag: string
+    category: string
+    time: string
+    title: string
+    content: string
+    likes: any[]
+    comments: number
+    views: number
+  }
+}
+export default function PostDetail({ post }: Props) {
+  const router = useRouter()
+  const handleNavigate = async () => {
+    if (post.category === '19') {
+      const isVerified = window.localStorage.getItem('isVerified')
+      if (isVerified !== 'true') {
+        if (
+          confirm(
+            '본인인증이 필요한 게시판입니다.\n본인인증 페이지로 이동하시겠습니까?',
+          )
+        ) {
+          userVerify()
+        }
+        return
+      }
+    }
+    router.push(`/detail/${post.id}`)
+  }
+  return (
+    <div className={style.detailContainer} onClick={() => handleNavigate()}>
+      <div className={style.contentContainer}>
+        <div className={style.title}>{post.title}</div>
+        {typeof window ? (
+          <div
+            className={style.content}
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(post.content),
+            }}
+          /> //js코드 실행 방지용 라이브러리 사용(해킹 방지)
+        ) : (
+          <div />
+        )}
+      </div>
+      <div className={style.postInfoContainer}>
+        <div className={style.postInfoWrapper}>
+          <Like />
+          <span className={style.likes}>
+            {post.likes ? post.likes.length : 0}
+          </span>
+        </div>
+        <div className={style.postInfoWrapper}>
+          <Comment />
+          <span className={style.likes}>{post.comments}</span>
+        </div>
+        <div className={style.postInfoWrapper}>
+          <View width="15" height="14" />
+          <span className={style.likes}>{post.views}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/_components/postPreview/_components/post.module.scss
+++ b/app/_components/postPreview/_components/post.module.scss
@@ -45,6 +45,9 @@
   font-weight: 400;
   line-height: normal;
 }
+.detailContainer {
+  cursor: pointer;
+}
 .contentContainer {
   width: 100%;
   padding: 16px 0;

--- a/app/_hooks/services/mutations/userRegister.tsx
+++ b/app/_hooks/services/mutations/userRegister.tsx
@@ -21,10 +21,12 @@ const signUpUser = async (userData: SignUpData): Promise<SignUpResponse> => {
 
 export const useSignUpUser = () => {
   const router = useRouter()
+  const localStorage = window.localStorage
   return useMutation({
     mutationFn: (userData: SignUpData) => signUpUser(userData),
     onSuccess: (data) => {
       console.log(data)
+      localStorage.setItem('isVerified', 'false')
       alert('회원가입이 완료되었습니다.')
       router.replace('/')
     },

--- a/app/_lib/userVerify.ts
+++ b/app/_lib/userVerify.ts
@@ -1,0 +1,59 @@
+import api from '../_api/commonApi'
+
+export default function userVerify() {
+  if (!window.IMP) return
+  const { IMP } = window
+  IMP.init(process.env.NEXT_PUBLIC_PORTONE_IDENTIFICATION_CODE)
+  IMP.certification(
+    {
+      merchant_uid: `mid_${new Date().getTime()}`,
+    },
+    callback,
+  )
+}
+async function callback(response: RequestResponse) {
+  const { success, error_msg, imp_uid } = response
+  if (success) {
+    const response = await api.patch(`/users/verification/${imp_uid}`, {})
+    if (response.code === 200) {
+      const localStorage = window.localStorage
+      localStorage.setItem('isVerified', 'true')
+    }
+    alert(response.message)
+  } else {
+    alert(`인증 실패: ${error_msg}`)
+  }
+}
+interface ICertification {
+  merchant_uid: string
+}
+interface RequestResponse {
+  success?: boolean
+  /**
+   * ### 결제 실패코드
+   * - 결제가 실패하는 경우 PG사 원천코드가 내려갑니다.
+   */
+  error_code?: string
+  /**
+   * ### 결제 실패메세지
+   * - 결제가 실패하는 경우 PG사 원천메세지가 내려갑니다.
+   */
+  error_msg?: string
+  /**
+   * ### 포트원 고유 결제번호
+   * - success가 false이고 사전 validation에 실패한 경우, imp_uid는 null일 수 있음
+   */
+  imp_uid: string
+}
+export interface Iamport {
+  init: (accountID: string | undefined) => void
+  certification: (
+    params: ICertification,
+    callback?: (response: RequestResponse) => void,
+  ) => void
+}
+declare global {
+  interface Window {
+    IMP?: Iamport
+  }
+}

--- a/app/detail/[id]/_components/Comment.tsx
+++ b/app/detail/[id]/_components/Comment.tsx
@@ -4,9 +4,9 @@ import styles from '../styles/comment.module.scss'
 import CommentInfo from './CommentInfo'
 import CommentWrite from './CommentWrite'
 import useGetComments from '@/app/_hooks/services/queries/comments'
-import formatDate from '@/app/_lib/formatDate'
 import useGetUserInfo from '@/app/_hooks/services/queries/userInfo'
 import { useState } from 'react'
+import { formatDate } from '@/app/_lib/formatDate'
 interface CommentProps {
   postId: number
 }

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -5,11 +5,11 @@ import { PageProps } from '@/.next/types/app/layout'
 import api from '@/app/_api/commonApi'
 import { formatDate } from '@/app/_lib/formatDate'
 import Navigation from './_components/Navigation'
+import userVerify from '@/app/_lib/userVerify'
 
 export default async function Detail({ params }: PageProps) {
   const response = await api.get(`/posts/${params.id}`)
   const data = response.data
-  console.log(data)
   return (
     <div className={styles.container}>
       <Navigation

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from 'next/font/local'
 import style from './_styles/layout.module.scss'
 import QueryProvider from './_components/reactQuery/QueryProvider'
 import LoginCheckProvider from './_api/LoginCheckProvider'
+import Script from 'next/script'
 
 const pretendard = localFont({
   src: [
@@ -44,6 +45,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <Script src="https://cdn.iamport.kr/v1/iamport.js" />
       <body className={pretendard.className}>
         <div className={style.container}>
           <QueryProvider>

--- a/app/mypage/(infoModify)/editInformation/_components/InfoEdit.tsx
+++ b/app/mypage/(infoModify)/editInformation/_components/InfoEdit.tsx
@@ -10,6 +10,7 @@ import InputText, { DisabledText } from '../../_components/InputText'
 
 import Button from '@/app/_components/button/Button'
 import Modal from '@/app/_components/common/modal/Modal'
+import userVerify from '@/app/_lib/userVerify'
 
 export default function InfoEdit() {
   const router = useRouter()
@@ -25,7 +26,6 @@ export default function InfoEdit() {
   const regex =
     /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()-_+=|\\{}[\]:;<>,.?/~]).{8,16}$/
   console.log('render', currentPassword)
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -39,10 +39,10 @@ export default function InfoEdit() {
       }
     }
     fetchData()
-  }, [])
+  }, [userInfo])
 
   const userVerified = () => {
-    console.log('TODO: 인증 이벤트 추가')
+    userVerify()
   }
   const handleChangeCurrentPassword = (e: ChangeEvent<HTMLInputElement>) => {
     console.log('handleChangeCurrentPassword')


### PR DESCRIPTION
1. 마이페이지 > 회원정보 수정에서 인증하기 버튼을 클릭할 경우 본인인증 팝업이 나타납니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/9e329ed8-8753-437c-b843-7202eecf6312)
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/d0cbcb7c-450b-490a-ae4d-b238c7387cd5)
(인증 완료시 버튼 비활성화)
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/ea7e493d-f5f4-495d-b411-c0c6f77a8c51)

3. 본인인증 상태가 아닌 경우 메인페이지에서 19 카테고리의 게시글을 클릭했을 때 본인인증 팝업이 나타납니다.
![image](https://github.com/waggle2/wagglewaggle/assets/87300419/15082097-a763-4e69-a27b-09c3077d354c)

- 게시글 클릭 시마다 user api를 추가로 호출하는 것을 막기 위해 localStorage에 isVerified 항목을 추가했습니다.
- 처음 회원가입 시 isVerifed = false로 localStorage에 추가되고, 본인인증 완료 시 true로 수정됩니다.

