### PR TITLE
[FE] 온보딩 페이지 UI 구현

### DIFF
--- a/app/onboarding/_components/Content.tsx
+++ b/app/onboarding/_components/Content.tsx
@@ -1,0 +1,147 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useState, useEffect } from 'react'
+import { animated, useTrail } from 'react-spring'
+import styles from '../styles/content.module.scss'
+export default function Content() {
+  const title = [
+    '나는 어떤 동물과 통할까요?\n와글와글에서 찾아봐요',
+    '다른 친구들이 바라보는\n 나는 어떤 동물일까요?',
+    '동물 포인트로\n 귀여운 아바타를 꾸며요',
+  ]
+  const content = [
+    '원하는 주제 / 답변에 따라\n 좌충우돌 연애 이야기를 나눠봐요',
+    '친구들이 전해준 동물 포인트로\n 숨겨진 나의 성향을 파악해요',
+    '프로필을 꾸며 와글와글 세상 속\n 나만의 모습을 만들어봐요',
+  ]
+  const [idx, setIdx] = useState(0)
+  const config = { mass: 10, tension: 3000, friction: 500 }
+  const [toggle, setToggle] = useState(false)
+  const [isLanding, setIsLanding] = useState(false)
+  useEffect(() => {
+    setToggle(!toggle)
+  }, [])
+  const router = useRouter()
+  const items = [
+    {
+      element: (
+        <div className={styles.title} onClick={() => handleAddIdx()}>
+          {title[idx]}
+        </div>
+      ),
+    },
+    {
+      element: (
+        <div className={styles.content} onClick={() => handleAddIdx()}>
+          {content[idx]}
+        </div>
+      ),
+    },
+    {
+      element: (
+        <div className={styles.image} onClick={() => handleAddIdx()}>
+          임시
+        </div>
+      ),
+    },
+    {
+      element: (
+        <div className={styles.circleContainer}>
+          {title.map((_, currentIdx) => {
+            return (
+              <div
+                className={
+                  currentIdx === idx ? `${styles.currentCircle}` : styles.circle
+                }
+              ></div>
+            )
+          })}
+        </div>
+      ),
+    },
+    {
+      element: (
+        <div className={styles.startButton} onClick={() => router.push('/')}>
+          와글와글 시작하기
+        </div>
+      ),
+    },
+    {
+      element: (
+        <span className={styles.navText}>
+          이미 회원이신가요?{' '}
+          <span className={styles.login} onClick={() => router.push('/login')}>
+            로그인
+          </span>
+        </span>
+      ),
+    },
+  ]
+  const initialTrail = useTrail(items.length, {
+    config,
+    from: { opacity: 0, y: -20 },
+    to: { opacity: 1, y: 0 },
+  })
+  const swipe = useTrail(3, {
+    config,
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+    reset: true,
+  })
+  const handleAddIdx = () => {
+    if (idx !== 2) {
+      setIdx(idx + 1)
+    } else {
+      setIdx(0)
+    }
+    setIsLanding(true)
+  }
+  return (
+    <div className={styles.container}>
+      {!isLanding ? (
+        initialTrail.map((style, idx) => (
+          <animated.div key={idx} style={style}>
+            <animated.div>{items[idx].element}</animated.div>
+          </animated.div>
+        ))
+      ) : (
+        <>
+          {swipe.map((styles, idx) => (
+            <animated.div key={idx} style={styles}>
+              <animated.div>{items[idx].element}</animated.div>
+            </animated.div>
+          ))}
+          <div className={styles.circleContainer}>
+            {title.map((_, currentIdx) => {
+              return (
+                <div
+                  className={
+                    currentIdx === idx
+                      ? `${styles.currentCircle}`
+                      : styles.circle
+                  }
+                ></div>
+              )
+            })}
+          </div>
+        </>
+      )}
+      {isLanding && (
+        <>
+          <div className={styles.startButton} onClick={() => router.push('/')}>
+            와글와글 시작하기
+          </div>
+          <span className={styles.navText}>
+            이미 회원이신가요?{' '}
+            <span
+              className={styles.login}
+              onClick={() => router.push('/login')}
+            >
+              로그인
+            </span>
+          </span>
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,9 @@
+import Content from './_components/Content'
+import styles from './styles/page.module.scss'
+export default function Onboarding() {
+  return (
+    <div className={styles.container}>
+      <Content />
+    </div>
+  )
+}

--- a/app/onboarding/styles/content.module.scss
+++ b/app/onboarding/styles/content.module.scss
@@ -1,0 +1,57 @@
+.startButton {
+  width: 398px;
+  border-radius: 6px;
+  background-color: #2fd714;
+  color: #fff;
+  font-size: 15px;
+  font-weight: normal;
+  padding: 15px 0;
+  cursor: pointer;
+  margin-bottom: 19px;
+}
+.title {
+  font-size: 24px;
+  margin-top: 100px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  white-space: pre-line;
+}
+.content {
+  font-size: 16px;
+  font-weight: normal;
+  color: #444444;
+  white-space: pre-line;
+}
+.image {
+  padding: 200px 0;
+  cursor: pointer;
+}
+@mixin circle {
+  width: 4px;
+  height: 4px;
+  border-radius: 50px;
+  background-color: #b3b3b4;
+  margin-bottom: 19px;
+}
+.circle {
+  @include circle;
+}
+.currentCircle {
+  @include circle;
+  background-color: #2fd714;
+}
+.circleContainer {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+.navText {
+  color: #b3b3b3;
+  font-size: 13px;
+  font-weight: normal;
+  .login {
+    color: #2a9418;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/app/onboarding/styles/page.module.scss
+++ b/app/onboarding/styles/page.module.scss
@@ -1,0 +1,14 @@
+.container {
+  max-width: 430px;
+  height: 100dvh;
+  text-align: center;
+  margin: 0 auto;
+  padding: 16px;
+  font-size: 20px;
+  overflow: hidden;
+  display: flex;
+  font-weight: 700;
+  flex-direction: column;
+  align-items: center;
+  background-color: #f5f5f5;
+}


### PR DESCRIPTION
온보딩 페이지의 UI를 구현했습니다.
![ezgif-1-9074b452e1](https://github.com/waggle2/wagglewaggle/assets/87300419/bb460370-a48f-468d-bace-519bc408bab1)
디자인팀 은서님께 초반 랜딩은 그대로, 화면 전환은 opacity 변경만 되어도 충분할 것 같다는 피드백을 받아서 해당 형태로 수정하였습니다.